### PR TITLE
Print cosmology before evaluating loglkl

### DIFF
--- a/montepython/io_mp.py
+++ b/montepython/io_mp.py
@@ -284,11 +284,22 @@ def create_output_files(command_line, data):
         data.out_name = os.path.join(
             command_line.folder, outname_base)+str(suffix)+'.txt'
         print('Creating %s\n' % data.out_name)
+        if command_line.print_cosmo:
+            data.cosmo_out_name = os.path.join(
+                command_line.folder, outname_base)+str(suffix)+'.cosmo'
+            data.cosmo_out = open(data.cosmo_out_name, 'w')
+            print('Creating %s\n' % data.cosmo_out_name)
     else:
         data.out_name = os.path.join(
             command_line.folder, outname_base)+command_line.chain_number+'.txt'
         data.out = open(data.out_name, 'w')
         print('Creating %s\n' % data.out_name)
+        if command_line.print_cosmo:
+            data.cosmo_out_name = os.path.join(
+                command_line.folder, outname_base)+command_line.chain_number+'.cosmo'
+            data.cosmo_out = open(data.cosmo_out_name, 'w')
+            print('Creating %s\n' % data.cosmo_out_name)
+    
     # in case of a restart, copying the whole thing in the new file
     if command_line.restart is not None:
         # Construct filename of old chain from input.

--- a/montepython/mcmc.py
+++ b/montepython/mcmc.py
@@ -786,7 +786,7 @@ def chain(cosmo, data, command_line):
                 data, sigma_eig, U, k, Cholesky, Rotation) is True:
             # Prints the position even if it is not accepted
             if command_line.print_cosmo:
-                io_mp.print_vector([data.cosmo_out], N, 0.0, data)
+                io_mp.print_vector([data.cosmo_out], 1, 0.0, data)
             newloglike = sampler.compute_lkl(cosmo, data)
         else:  # reject step
             rej += 1

--- a/montepython/mcmc.py
+++ b/montepython/mcmc.py
@@ -784,6 +784,9 @@ def chain(cosmo, data, command_line):
         # multiplicity of the point and start the loop again
         if get_new_position(
                 data, sigma_eig, U, k, Cholesky, Rotation) is True:
+            # Prints the position even if it is not accepted
+            if command_line.print_cosmo:
+                io_mp.print_vector([data.cosmo_out], N, 0.0, data)
             newloglike = sampler.compute_lkl(cosmo, data)
         else:  # reject step
             rej += 1

--- a/montepython/parser_mp.py
+++ b/montepython/parser_mp.py
@@ -566,6 +566,9 @@ def create_parser():
         <**>--display-each-chi2<**> : bool
             <++>Shows the effective chi2 from each likelihood and the total.<++>
             Useful e.g. if you run at the bestfit point with -f 0 (flag)<++>
+        <**>--print-cosmo<**> : bool
+            <++>Prints CLASS inputs before each loglkl evaluation.<++>
+            Inputs are printed in a separate file from the chains. (flag)<++>
         <**>--parallel-chains<**> : bool
             <++>Option for when running parallel without MPI<++>.
             Informs the code you are running parallel chains. This
@@ -809,6 +812,11 @@ def create_parser():
     # display option
     runparser.add_argument('--display-each-chi2', help=helpdict['display-each-chi2'],
                            dest='display_each_chi2', action='store_true')
+    
+    # print cosmo inputs before evaluating loglkl
+    runparser.add_argument('--print-cosmo', help=helpdict['print-cosmo'],
+                           dest='print_cosmo', action='store_true')
+
     # -- parallel chains without MPI (OPTIONAL)
     runparser.add_argument('--parallel-chains', help=helpdict['parallel-chains'],
                            action='store_true')


### PR DESCRIPTION
Can now be run as

`python montepython_public/montepython/MontePython.py -p XXX.param -o XXX --print-cosmo`

This creates a file (with the name XXX_1.cosmo) for every ordinary chain file (named XXX_1.txt) which contains exactly the same information, but writes a new line every time the cosmology is being loaded, before CLASS is executed with it. Thus, to track down CLASS errors, one can look in the last line of XXX_1.cosmo for a crashed run and rerun CLASS with the offending input outside of MontePython.